### PR TITLE
make sublime-run command start a cmd window in Windows

### DIFF
--- a/CSharpSingleFileBuild.sublime-build
+++ b/CSharpSingleFileBuild.sublime-build
@@ -17,7 +17,7 @@
       "shell" : true,
 
       "windows" : {
-        "cmd" : "$file_base_name.exe"
+        "cmd": ["start", "cmd", "/k", "${file_path}/${file_base_name}.exe"]
       }
     }
   ]


### PR DESCRIPTION
Now Running a compiled exe opens it in the command prompt. This helps in seeing the last output before the window flash closes.